### PR TITLE
Fix docstring to mention ODBC instead of Postgres

### DIFF
--- a/src/Database/Persist/ODBC.hs
+++ b/src/Database/Persist/ODBC.hs
@@ -198,7 +198,7 @@ withStmt' stmt vals = do
               )
               mr
 
--- | Information required to connect to a PostgreSQL database
+-- | Information required to connect to an ODBC database
 -- using @persistent@'s generic facilities.  These values are the
 -- same that are given to 'withODBCPool'.
 data OdbcConf = OdbcConf


### PR DESCRIPTION
I guess this was missed when forking from `persistent-postgresql` :)