### PR TITLE
use sqlint64 for primary key in MSSQL

### DIFF
--- a/src/Database/Persist/MigrateMSSQL.hs
+++ b/src/Database/Persist/MigrateMSSQL.hs
@@ -67,7 +67,7 @@ migrate' allDefs getter val = do
       ([], [], _) -> do
         let idtxt = case entityPrimary val of
                 Just pdef -> concat [" PRIMARY KEY (", intercalate "," $ map (escapeDBName . fieldDB) $ compositeFields pdef, ")"]
-                Nothing  -> concat [escapeDBName $ fieldDB $ entityId val, " INT NOT NULL IDENTITY(1,1) PRIMARY KEY "]
+                Nothing  -> concat [escapeDBName $ fieldDB $ entityId val, " BIGINT NOT NULL IDENTITY(1,1) PRIMARY KEY "]
         let addTable = AddTable $ concat
                             -- Lower case e: see Database.Persist.Sql.Migration
                 [ "CREATe TABLE "


### PR DESCRIPTION
this half reverts 7e2b88e044715d38b63dde5db3a629c0a21a7db0

the auto id column defaults to 64bit and so does the reference column
I don't know about DB2, but MSSQL is picky about the types in foreign key
constraint, see the yesod scaffold log:

```
Migrating: CREATe TABLE [user]([id] INT NOT NULL IDENTITY(1,1) PRIMARY KEY ,[ident] VARCHAR(1000) NOT NULL,[password] VARCHAR(1000) NULL)
30/Jul/2015:12:17:01 +0200 [Debug#SQL] CREATe TABLE [user]([id] INT NOT NULL IDENTITY(1,1) PRIMARY KEY ,[ident] VARCHAR(1000) NOT NULL,[password] VARCHAR(1000) NULL); []
Migrating: CREATe TABLE [email]([id] INT NOT NULL IDENTITY(1,1) PRIMARY KEY ,[email] VARCHAR(1000) NOT NULL,[user] BIGINT NOT NULL,[verkey] VARCHAR(1000) NULL)
Migrating: ALTER TABLE [user] ADD CONSTRAINT [unique_user] UNIQUE([ident])
Migrating: ALTER TABLE [email] ADD CONSTRAINT [unique_email] UNIQUE([email])
Migrating: ALTER TABLE [email] ADD CONSTRAINT [email_user_fkey] FOREIGN KEY([user]) REFERENCES [user]([id])
devel.hs: SqlError {seState = "[\"42000\",\"42000\"]", seNativeError = -1, seErrorMsg = "execute execute: [\"1778: [Microsoft][ODBC Driver 11 for SQL Server][SQL Server]Column 'user.id' is not the same data type as referencing column 'email.user' in foreign key 'email_user_fkey'.\",\"1750: [Microsoft][ODBC Driver 11 for SQL Server][SQL Server]Could not create constraint. See previous errors.\"]"}
Exit code: ExitFailure 1
```