### PR TITLE
Set bounds on resourcet

### DIFF
--- a/persistent-odbc.cabal
+++ b/persistent-odbc.cabal
@@ -49,7 +49,7 @@ library
                     , HDBC          >= 2.2
                     , HDBC-odbc     >= 2.4
                     , monad-logger
-                    , resourcet
+                    , resourcet     >= 1.1.11 && < 1.2
                     , monad-control
                     , persistent-template >= 2.1 && < 3
                     , persistent    >= 2.6.1 && < 3


### PR DESCRIPTION
:sparkles: _**This is an old work account. Please reference @brandonchinn178 for all future communication**_ :sparkles:
<!-- updated by mention_personal_account_in_comments.py -->

---

resourcet-1.2 changed the type of `with` to use `MonadUnliftIO` instead of `MonadBaseControl`. This is just a bounds check to make sure we're dealing with the correct `resourcet`. There can be another PR for bumping the `resourcet` version