### PR TITLE
Fixed some issues in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 persistent-odbc
 ===============
-Uses the [Persistent package](http://hackage.haskell.org/package/persistent) and [HDBC-odbc](http://hackage.haskell.org/package/hdbc-odbc)
+Uses the [Persistent package](http://hackage.haskell.org/package/persistent) and [HDBC-odbc](http://hackage.haskell.org/package/HDBC-odbc)
 to access databases via ODBC.
 
-Thanks to Dmitry Olshansky at https://github.com/odr/persistent-odbc/
+Thanks to Dmitry Olshansky at <https://github.com/odr/persistent-odbc/>
 for doing the initial hookup to hdbc-odbc.
 
 Supports Postgres, MySql, MS Sql Server, Oracle, DB2, and SQLite.
 
 see TestODBC.hs for usage and tests.
 
-##How to get started using cabal >= 1.18
+## How to get started using cabal >= 1.18
 
 ```text
 git clone https://github.com/gbwey/persistent-odbc
@@ -34,25 +34,31 @@ e.g. for postgresql
 | Oracle >= 12c          | dsn=oracle_test | :main on |
 | Sqlite                 | dsn=sqlite_test | :main q |
 
-####Limit and Offset in Ms Sql Server and Oracle
+#### Limit and Offset in Ms Sql Server and Oracle
+
   MSSQL True for MS Sql Server 2012 which has limit and offset support (esqueleto as well).
   MSSQL False for MS Sql Server pre 2012 only supports limit using Persistent's select* operations. (select top n ...).
 
   Oracle True for Oracle >=12c which has limit and offset support (esqueleto as well).
   Oracle False for Oracle <12c where there is no limit and offset support.
 
-####Ms Sql Server and blobs
+#### Ms Sql Server and blobs
+
   Blobs are problematic in hdbc-odbc.
 
-####Ms Sql Server and deleteCascadeWhere
+#### Ms Sql Server and deleteCascadeWhere
+
   Can cause segfault in Ms Sql Server.
 
-####Oracle and nulls
+#### Oracle and nulls
+
   Treats empty string as a null (oracle issue).
 
-####Oracle and sorting blobs
+#### Oracle and sorting blobs
+
   Cannot sort on a blob field (oracle issue).
 
-####DB2 and blobs
+#### DB2 and blobs
+
   Blobs don't support nulls (both insert and select) in this version of persistent-odbc (also doesn't work in hdbc-odbc).
   Select returns the blob values as unpacked strings at the moment (if there is interest in getting this fixed let me know).


### PR DESCRIPTION
- The link to HDBC-odbc was incorrect, fixed
- The link to the fork of persistent-odbc was plain-text only, added angle-brackets so it can be clicked as well
- One `<h2>` and several `<h4>` headings were missing the space between the last `#` and title, fixed